### PR TITLE
fix typo in start of apci thing with the word results. being misspelled as resaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ As you are following the guide and get to the [Gathering Files](https://dortania
 
 **APCI**
 
-For this, you are going to want to download a tool called [SSDTTime](https://github.com/corpnewt/SSDTTime). Running this tool, you are first going to choose option **P** to dump you DSDT. Then you are going to select option **3** to make a SSDT-EC.aml. It should be in the resaults folder. Copy this to your EFI -> APCI folder, as per the OpenCore guide instructions.
+For this, you are going to want to download a tool called [SSDTTime](https://github.com/corpnewt/SSDTTime). Running this tool, you are first going to choose option **P** to dump you DSDT. Then you are going to select option **3** to make a SSDT-EC.aml. It should be in the results folder. Copy this to your EFI -> APCI folder, as per the OpenCore guide instructions.
 
 You will also need the [SSDT-CPUR](https://github.com/dortania/Getting-Started-With-ACPI/blob/master/extra-files/compiled/SSDT-CPUR.aml) in the ACPI folder.
 


### PR DESCRIPTION
just to fix a typo in the readme file. does not change anything else. just fixes a single typo in the readme file. that is it